### PR TITLE
Minor updates

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,7 @@ fn main() {
 
     // Generate bindings
     let bindings = bindgen::builder()
-        .header("src/include/libbpfcontain.h")
+        .header("bindings.h")
         .derive_default(true)
         .derive_eq(true)
         .derive_partialeq(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod utils;
 
 mod bindings;
 mod ns;
+mod uprobes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,12 @@ fn main() -> Result<()> {
                     Arg::with_name("policy")
                         .required(true)
                         .help("The policy to run"),
+                )
+                .arg(
+                    Arg::with_name("command")
+                        .multiple(true)
+                        .last(true)
+                        .help("Override policy command"),
                 ),
         );
 

--- a/src/subcommands/run.rs
+++ b/src/subcommands/run.rs
@@ -31,14 +31,23 @@ pub fn main(args: &ArgMatches, config: &Settings) -> Result<()> {
     // Containerize
     containerize(&policy).context("Failed to containerize")?;
 
+    // Get entrypoint as a vector of strings
+    let cmd_vec = {
+        if let Some(cmd) = args
+            .values_of("command")
+            .map(|vals| vals.collect::<Vec<_>>())
+        {
+            cmd
+        } else {
+            policy.cmd.split_whitespace().collect::<Vec<_>>()
+        }
+    };
+
     // Parse out command
-    let command = policy
-        .cmd
-        .split_whitespace()
-        .nth(0)
-        .context("Failed to get command")?;
+    let command = cmd_vec.iter().nth(0).context("Failed to get command")?;
+
     // Parse out args
-    let args: Vec<_> = policy.cmd.split_whitespace().skip(1).collect();
+    let args: Vec<_> = cmd_vec.iter().skip(1).collect();
 
     let err = Command::new(command).args(args).exec();
 

--- a/src/uprobes.rs
+++ b/src/uprobes.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// BPFContain - Container security with eBPF
+// Copyright (C) 2020  William Findlay
+//
+// Dec. 29, 2020  William Findlay  Created this.
+
+use std::fs::read;
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+use goblin::elf::{Elf, Sym};
+
+/// Resolves symbols from an ELF file
+/// Based on https://github.com/ingraind/redbpf/blob/main/redbpf/src/symbols.rs
+struct SymbolResolver<'a> {
+    elf: Elf<'a>,
+}
+
+impl<'a> SymbolResolver<'a> {
+    /// Find a symbol offset within a file specified by `pathname`
+    pub fn find_in_file(pathname: &Path, symbol: &str) -> Result<Option<usize>> {
+        let bytes = read(pathname).context("Failed to read ELF")?;
+        let resolver = Self::parse(&bytes).context("Failed to parse ELF")?;
+        let offset = resolver.find_offset(symbol);
+        Ok(offset)
+    }
+
+    /// Parse an ELF file and return a [`SymbolResolver`]
+    pub fn parse(bytes: &[u8]) -> Result<SymbolResolver> {
+        let elf = Elf::parse(bytes)?;
+        Ok(SymbolResolver { elf })
+    }
+
+    /// Resolve a symbol in the ELF file
+    fn resolve_sym(&self, symbol: &str) -> Option<Sym> {
+        self.elf.syms.iter().find(|sym| {
+            self.elf
+                .strtab
+                .get(sym.st_name)
+                .and_then(|sym| sym.ok())
+                .map(|sym| sym == symbol)
+                .unwrap_or(false)
+        })
+    }
+
+    /// Find the offset of a symbol in the ELF file
+    pub fn find_offset(&self, symbol: &str) -> Option<usize> {
+        self.resolve_sym(symbol)
+            .and_then(|sym| Some(sym.st_value as usize))
+    }
+}
+
+pub trait FindSymbolUprobeExt {
+    fn attach_uprobe_symbol(
+        &mut self,
+        retprobe: bool,
+        pid: i32,
+        pathname: &Path,
+        symbol: &str,
+    ) -> Result<libbpf_rs::Link>;
+}
+
+impl FindSymbolUprobeExt for libbpf_rs::Program {
+    fn attach_uprobe_symbol(
+        &mut self,
+        retprobe: bool,
+        pid: i32,
+        pathname: &Path,
+        symbol: &str,
+    ) -> Result<libbpf_rs::Link> {
+        // Find symbol in the ELF file
+        let offset = SymbolResolver::find_in_file(pathname, symbol)
+            .context("Error finding symbol")?
+            .context("Failed to find symbol")?;
+
+        // Explicitly null terminate pathname
+        // TODO: file bug report in libbpf_rs
+        let mut pathname = String::from(
+            pathname
+                .to_str()
+                .context("Failed to convert pathname to string")?,
+        );
+        pathname.push_str("\0");
+
+        // Use the offset we found to attach the probe
+        Ok(self
+            .attach_uprobe(retprobe, pid, pathname, offset)
+            .context("Failed to attach uprobe")?)
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,6 @@
 // Dec. 29, 2020  William Findlay  Created this.
 
 use anyhow::{bail, Context, Result};
-use goblin::Object;
 use std::fs;
 use std::os::linux::fs::MetadataExt;
 use std::path::{Path, PathBuf};
@@ -27,52 +26,6 @@ pub fn bump_memlock_rlimit() -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Locate a symbol `symbol_name` in an ELF binary represented by the Goblin
-/// Elf struct `elf`.
-pub fn get_symbol(elf: &goblin::elf::Elf, symbol_name: &str) -> Result<goblin::elf::Sym> {
-    // Grab the symbol table and string table
-    let symtab = &elf.syms;
-    let strtab = &elf.strtab;
-
-    // Locate the symbol
-    let sym = symtab.iter().find(|sym| {
-        if let Some(sym) = strtab.get(sym.st_name) {
-            if let Ok(name) = sym {
-                if name == symbol_name {
-                    return true;
-                }
-            }
-        }
-        false
-    });
-
-    match sym {
-        Some(sym) => Ok(sym),
-        None => bail!("Failed to find symbol {}", symbol_name),
-    }
-}
-
-/// Get the offset of a symbol `symbol_name` relative to .text in an ELF binary
-/// located at `binary_path`.
-pub fn get_symbol_offset(binary_path: &str, symbol_name: &str) -> Result<usize> {
-    let path = Path::new(binary_path);
-    let buffer = fs::read(path)?;
-
-    // Parse the ELF file
-    let elf = match Object::parse(&buffer)? {
-        Object::Elf(elf) => elf,
-        _ => bail!("Failed to parse ELF file {}", binary_path),
-    };
-
-    // Find the relative offset of symbol
-    let symbol = get_symbol(&elf, symbol_name)?;
-    let offset = symbol.st_value as usize;
-
-    log::debug!("{} {}={:#0x}", binary_path, symbol_name, offset);
-
-    Ok(offset as usize)
 }
 
 /// Returns a `(st_dev, st_ino)` pair for the path `path`.


### PR DESCRIPTION
- Use bindings.h to generate bindings
- Add the ability to override a policy entrypoint using `bpfcontain run -- <entrypoint command>`
- Refactor and split uprobe symbol resolution logic out of bpf_program.rs