### PR TITLE
Small updates

### DIFF
--- a/examples/mysql.yml
+++ b/examples/mysql.yml
@@ -1,0 +1,55 @@
+name: mysqld
+cmd: 'mysqld --user=root'
+defaultTaint: false
+
+allow:
+  # Access to log files
+  - file: {pathname: /var/log/mysqld, access: rw}
+  - file: {pathname: /var/log/mysqld/*log, access: ra}
+
+  # Access to /var/lib/mysql
+  - file: {pathname: /var/lib/mysql, access: rw}
+  - file: {pathname: /var/lib/mysql/**/*, access: rwd}
+
+  # Access to /etc/mysql
+  - file: {pathname: /etc/mysql, access: r}
+  - file: {pathname: /etc/mysql/**/*, access: r}
+
+  # Create pidfile and socket
+  - file: {pathname: /run/mysqld, access: rw}
+  - file: {pathname: /run/mysqld/**/*, access: rwd}
+
+  # Read configuration
+  - file: {pathname: /etc/mysql, access: r}
+  - file: {pathname: /etc/mysql, access: r}
+  - file: {pathname: /usr/share/zoneinfo, access: r}
+  - file: {pathname: /usr/share/zoneinfo/**/*, access: r}
+
+  # Shared libraries loaded at runtime
+  - file: {pathname: /var/lib/mysql/plugin/*.so, access: mr}
+  - file: {pathname: /usr/lib/libnss_files-*.*.so, access: mr}
+
+  # Allow ipc with httpd
+  - ipc: httpd
+
+  # Allow sending signals to existing mysqld instances
+  - ipc: mysqld
+
+  # Allow mysqld to create a new network socket
+  # (Necessary to pass assertions)
+  - net: server
+
+  # Needed to run as root
+  - capability:
+    - dacoverride
+    - dacreadsearch
+
+taint:
+  # Taint when performing ipc with httpd
+  - ipc: httpd
+  # Taint when sending or receiving any network traffic
+  - net: [send, recv]
+
+deny:
+  # Explicitly deny sending or receiving any network traffic
+  - net: [send, recv]

--- a/src/bindings/policy.rs
+++ b/src/bindings/policy.rs
@@ -99,7 +99,7 @@ pub mod bitflags {
         #[derive(Default)]
         pub struct FileAccess :raw::file_permission_t::Type {
             const MAY_READ      = raw::file_permission_t::BPFCON_MAY_READ;
-            const MAY_WRITE     = raw::file_permission_t::BPFCON_MAY_WRITE;
+            const MAY_WRITE     = raw::file_permission_t::BPFCON_MAY_WRITE | raw::file_permission_t::BPFCON_MAY_APPEND;
             const MAY_EXEC      = raw::file_permission_t::BPFCON_MAY_EXEC;
             const MAY_APPEND    = raw::file_permission_t::BPFCON_MAY_APPEND;
             const MAY_DELETE    = raw::file_permission_t::BPFCON_MAY_DELETE;
@@ -122,6 +122,7 @@ pub mod bitflags {
                 "readAppend" => return Ok(Self::MAY_READ | Self::MAY_APPEND),
                 "library" => return Ok(Self::MAY_READ | Self::MAY_EXEC_MMAP),
                 "exec" => return Ok(Self::MAY_READ | Self::MAY_EXEC),
+                "any" => return Ok(Self::all()),
                 _ => {}
             };
 

--- a/src/bpf/include/audit.h
+++ b/src/bpf/include/audit.h
@@ -20,20 +20,16 @@
 static audit_level_t decision_to_audit_level(policy_decision_t decision,
                                              bool default_deny)
 {
-    switch (decision) {
-    case BPFCON_ALLOW:
-        return AUDIT_ALLOW;
-    case BPFCON_TAINT:
-        return AUDIT_TAINT;
-    case BPFCON_DENY:
+    if (decision & BPFCON_DENY) {
         return AUDIT_DENY;
-    case BPFCON_NO_DECISION:
-        if (default_deny)
-            return AUDIT_DENY;
-        return AUDIT__NONE;
-    default:
-        return AUDIT__NONE;
+    } else if (decision & BPFCON_TAINT) {
+        return AUDIT_TAINT;
+    } else if (decision & BPFCON_ALLOW) {
+        return AUDIT_ALLOW;
+    } else if (default_deny) {
+        return AUDIT_DENY;
     }
+    return AUDIT__NONE;
 }
 
 /**

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -225,7 +225,7 @@ pub fn load_policy_recursive(skel: &mut Skel, policy_dir: &str) -> Result<()> {
         {
             Ok(policy) => policy,
             Err(e) => {
-                log::warn!("{}", e);
+                log::warn!("{:?}", e);
                 continue;
             }
         };
@@ -237,7 +237,7 @@ pub fn load_policy_recursive(skel: &mut Skel, policy_dir: &str) -> Result<()> {
         )) {
             Ok(_) => {}
             Err(e) => {
-                log::warn!("{}", e);
+                log::warn!("{:?}", e);
                 continue;
             }
         }


### PR DESCRIPTION
- Added a new example policy for MySQL over a Unix socket
- Minor tweaks to policy language/semantics
- Changes to default Unix IPC enforcement to enable socket creation/binding/listening without a peer