### PR TITLE
ci: fix vagrant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     # virtualization. The actual CI workflow will run on an archlinux VM that we spin up
     # using Vagrant. The reason behind this is that we need bleeding edge kernels to test
     # BPFContain, since it uses the latest eBPF features.
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
       - name: Cancel Previous Workflow Runs


### PR DESCRIPTION
macos-latest is now macos-11 which does not support vagrant yet according to GA folks